### PR TITLE
Change the rule about magic comments

### DIFF
--- a/ruby.en.md
+++ b/ruby.en.md
@@ -4,7 +4,7 @@
 - [Indentation](#indentation)
 - [Whitespaces](#whitespaces)
 - [Empty lines](#empty-lines)
-- [Magic comment](#magic-comments)
+- [Magic comment](#character-encoding-and-magic-comments)
 - [Line columns](#line-columns)
 - [Numbers](#numbers)
 - [Strings](#strings)
@@ -77,10 +77,11 @@ To ensure readability and consistency within the code, the guide presents a numb
 
 - **[MUST]** Do not put empty lines at the end of a file.
 
-## Magic comments
+## Character encoding and magic comments
 
-- **[MUST]** Do not use magic comments on Ruby 2.0+ because UTF-8 is set as the default encoding after Ruby 2.0.
-- **[MUST]** Use the following style for magic comments on Ruby 1.9.x.
+- **[MUST]** Use UTF-8 as scripts' character encoding for no particular reason.
+- **[SHOULD]** Do not use magic comments on Ruby 2.0+ and UTF-8 encoding because UTF-8 is the default encoding after Ruby 2.0.
+- **[MUST]** Use the following style for magic comments when you need.
 
     ```ruby
     # coding: utf-8

--- a/ruby.ja.md
+++ b/ruby.ja.md
@@ -4,7 +4,7 @@
 - [インデント](#indentation)
 - [空白](#whitespaces)
 - [空行](#empty-lines)
-- [マジックコメント](#magic-comments)
+- [文字エンコーディングとマジックコメント](#character-encoding-and-magic-comments)
 - [1行の文字数](#line-columns)
 - [数値](#numbers)
 - [文字列](#strings)
@@ -84,10 +84,11 @@ Ruby プログラマとしての素養をある程度備えている者なら誰
 
 - **[MUST]** ファイルの末尾に空行を置いてはならない。
 
-<a name="magic-comments"></a>
-## マジックコメント
-- **[MUST]** Ruby 2.0 以降は UTF-8 がデフォルトになったのでマジックコメントを書かない。
-- **[MUST]** Ruby 1.9.x では以下の形式でマジックコメントを書くこと。
+<a name="character-encoding-and-magic-comments"></a>
+## 文字エンコーディングとマジックコメント
+- **[MUST]** 特別な理由がない場合はスクリプトのエンコーディングは UTF-8 にすること。
+- **[SHOULD]** Ruby 2.0 以降は UTF-8 がデフォルトになったので、スクリプトのエンコーディングが UFT-8 の場合はマジックコメントを書かない。
+- **[MUST]** マジックコメントが必要な場合は以下の形式で書くこと。
 
     ```ruby
     # coding: utf-8


### PR DESCRIPTION
In this patch, I suggest that we change the rule about magic comments as the following:
- Move the rule on ruby 2.0+ to MUST
- Specify "どうしてもマジックコメントが必要な場合" (== working on ruby 1.9.x)
- Fix a wrong target version (en) (1.9+ to 1.9.x)
