### PR TITLE
Fix typo

### DIFF
--- a/ruby.en.md
+++ b/ruby.en.md
@@ -236,7 +236,7 @@ To ensure readability and consistency within the code, the guide presents a numb
     ```
 
 - **[MUST]** Use `{}` to write empty hashes.
-- **[MUST]** For multiline hashes, write the first item just after `{`, increment the level of indentation after the second items, put `}` on an independent line, and align the line of `{` to the head of the line of the first item.
+- **[MUST]** For multiline hashes, write the first item just after `{`, increment the level of indentation after the second items, put `}` on an independent line, and align the line of `}` to the head of the line of the first item.
 
     ```ruby
     # good


### PR DESCRIPTION
For multiline hashes, <q>align the line of `{` to the head of the line of the first item</q> doesn't make sense. Both mean the same line.

I think `{` should be replaced with `}`.
