### PR TITLE
Fix/fix/hash rocket dsl

### DIFF
--- a/ruby.en.md
+++ b/ruby.en.md
@@ -509,11 +509,6 @@ To ensure readability and consistency within the code, the guide presents a numb
       ActionMailer::Base.delivery_method :smtp,
           host: 'localhost',
           port: 25
-
-      # you can write like that on 1.9+
-      ActionMailer::Base.delivery_method :smtp,
-          host: 'localhost',
-          port: 25
       ```
 
 ## BEGIN and END

--- a/ruby.ja.md
+++ b/ruby.ja.md
@@ -519,11 +519,6 @@ Ruby プログラマとしての素養をある程度備えている者なら誰
       ActionMailer::Base.delivery_method :smtp,
           host: 'localhost',
           port: 25
-
-      # you can write like that on 1.9
-      ActionMailer::Base.delivery_method :smtp,
-          host: 'localhost',
-          port: 25
       ```
 
 <a name="begin-and-end"></a>


### PR DESCRIPTION
https://github.com/cookpad/styleguide/pull/11

Removing statement for 1.9+ because I think we can drop support for Ruby 1.8.x.
