### PR TITLE
fix mistaking do/end

### DIFF
--- a/ruby.en.md
+++ b/ruby.en.md
@@ -407,14 +407,14 @@ To ensure readability and consistency within the code, the guide presents a numb
 
     ```ruby
     # good
-    puts [1, 2, 3].map {|i|
-      i * i
-    }
-
-    # bad
     puts [1, 2, 3].map do |i|
       i * i
     end
+
+    # bad
+    puts [1, 2, 3].map {|i|
+      i * i
+    }
 
     # good
     [1, 2, 3].map {|n|

--- a/ruby.ja.md
+++ b/ruby.ja.md
@@ -416,14 +416,14 @@ Ruby プログラマとしての素養をある程度備えている者なら誰
 
     ```ruby
     # good
-    puts [1, 2, 3].map {|i|
-      i * i
-    }
-
-    # bad
     puts [1, 2, 3].map do |i|
       i * i
     end
+
+    # bad
+    puts [1, 2, 3].map {|i|
+      i * i
+    }
 
     # good
     [1, 2, 3].map {|n|


### PR DESCRIPTION
コード修正箇所の直前の記述、
- [MUST] ブロック付きメソッド呼び出しでは、do/end 記法でブロックを書くこと。i.e. blockの副作用が目的
- [MUST] ブロック付きメソッド呼び出しの戻り値に対して処理を行う場合は、ブロックを中括弧で書くこと。

を見る限り、{}ではなくdo/endが正しいのかな、と思ったのですが合ってますかね？
私の勘違いでしたらすいません。
