### PR TITLE
Fix ruby example

### DIFF
--- a/ruby.en.md
+++ b/ruby.en.md
@@ -508,8 +508,8 @@ To ensure readability and consistency within the code, the guide presents a numb
 
       ```ruby
       ActionMailer::Base.delivery_method :smtp,
-          host: 'localhost',
-          port: 25
+        host: 'localhost',
+        port: 25
       ```
 
 ## BEGIN and END

--- a/ruby.ja.md
+++ b/ruby.ja.md
@@ -517,8 +517,8 @@ Ruby プログラマとしての素養をある程度備えている者なら誰
 
       ```ruby
       ActionMailer::Base.delivery_method :smtp,
-          host: 'localhost',
-          port: 25
+        host: 'localhost',
+        port: 25
       ```
 
 <a name="begin-and-end"></a>


### PR DESCRIPTION
> For writing a DSL-like method call in multiple lines, put the first argument just after the method name, increment the level of indentation from the next line, and put each argument on a new line.

Does this mean, should the example be like this?
Forgive me if I'm wrong.
Thanks!