### PR TITLE
Make "do not use else for unless" MUST

### DIFF
--- a/ruby.en.md
+++ b/ruby.en.md
@@ -336,7 +336,7 @@ To ensure readability and consistency within the code, the guide presents a numb
 
 - **[SHOULD]** Use `unless condition`, instead of `if !condition`.
 - **[SHOULD]** Use `until condition`, instead of `while !condition`.
-- **[SHOULD]** Do not use `else` for `unless`.
+- **[MUST]** Do not use `else` for `unless`.
 - **[MUST]** Put a line break just after the condition clause of `if`, `unless`, and `case`.  Do not follow a body code.
 - **[MUST]** Do not use `then` and `:` for the condition clause of `if`, `unless`, and `case`.
 - **[MUST]** Put a line break just after the condition clause of `while` and `until`.  Do not follow a body code.

--- a/ruby.ja.md
+++ b/ruby.ja.md
@@ -353,7 +353,7 @@ Ruby プログラマとしての素養をある程度備えている者なら誰
 
 - **[SHOULD]** `if !condition` の代わりに `unless condition` と書くこと。
 - **[SHOULD]** `while !condition` の代わりに `until condition` と書くこと。
-- **[SHOULD]** `unless` に対して `else` を使ってはならない。
+- **[MUST]** `unless` に対して `else` を使ってはならない。
 - **[MUST]** `if`、`unless`、および `case` の条件式の後ろは改行すること。同じ行に本体コードを続けて書いてはならない。
 - **[MUST]** `if`、`unless`、および `case` で `then` や `:` を使用してはならない。
 - **[MUST]** `while` および `until` の条件式の後ろは改行すること。同じ行に本体コードを続けて書いてはならない。


### PR DESCRIPTION
I'd like to change the level of the rule "Do not use `else` for `unless`" from **SHOULD** to **MUST**.
There's no case that writing like that make better the code (AKAIK) and it is easy to follow the rule (just swap blocks).

What do you think?
