### PR TITLE
Added missing else in guard statement

### DIFF
--- a/swift.en.md
+++ b/swift.en.md
@@ -260,7 +260,7 @@ if !isLoggedIn {
 
 ```swift
 // Good
-guard let user = manager.currentUser {
+guard let user = manager.currentUser else {
     return
 }
 label.text = user.name

--- a/swift.ja.md
+++ b/swift.ja.md
@@ -261,7 +261,7 @@ if !isLoggedIn {
 
 ```swift
 // Good
-guard let user = manager.currentUser {
+guard let user = manager.currentUser else {
     return
 }
 label.text = user.name


### PR DESCRIPTION
In one of the examples in the **Optional** section `else` is missing from the guard statement.