### PR TITLE
Adapt .rubocop.yml to RuboCop v0.77.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,7 +47,7 @@ Layout/TrailingWhitespace:
 ########################
 
 # [MUST] Do not put empty lines at the end of a file.
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   EnforcedStyle: final_newline
 
 ########################


### PR DESCRIPTION
RuboCop v0.77.0 says:

```
Error: The `Layout/TrailingBlankLines` cop has been renamed to `Layout/TrailingEmptyLines`.
```

cf. https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0770-2019-11-27