### PR TITLE
Adapt .rubocop.yml to RuboCop v0.78.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,7 +65,7 @@ Layout/TrailingEmptyLines:
 ########################
 
 # [SHOULD] Keep lines shorter than 128 characters.
-Metrics/LineLength:
+Layout/LineLength:
   Max: 128
 
 ########################


### PR DESCRIPTION
RuboCop v0.78.0 says:

```
Metrics/LineLength has the wrong namespace - should be Layout
```

cf. https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0780-2019-12-18