### PR TITLE
Clarify about empty lines around EOF

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/TrailingWhitespace:
 # Empty lines
 ########################
 
-# [MUST] Do not put empty lines at the end of a file.
+# [MUST] Leave exactly one newline at the end of a file.
 Layout/TrailingEmptyLines:
   EnforcedStyle: final_newline
 

--- a/ruby.en.md
+++ b/ruby.en.md
@@ -75,7 +75,21 @@ To ensure readability and consistency within the code, the guide presents a numb
 
 ## Empty lines
 
-- **[MUST]** Do not put empty lines at the end of a file.
+- **[MUST]** Leave exactly one newline at the end of a file.
+
+    ``` ruby
+    # bad
+    class Foo; end
+
+    # EOF
+
+    # bad
+    class Foo; end # EOF
+
+    # good
+    class Foo; end
+    # EOF
+    ```
 
 ## Character encoding and magic comments
 

--- a/ruby.ja.md
+++ b/ruby.ja.md
@@ -82,7 +82,21 @@ Ruby プログラマとしての素養をある程度備えている者なら誰
 <a name="empty-lines"></a>
 ## 空行
 
-- **[MUST]** ファイルの末尾に空行を置いてはならない。
+- **[MUST]** ファイルの末尾ではちょうど1回だけ改行する。
+
+    ``` ruby
+    # bad
+    class Foo; end
+
+    # EOF
+
+    # bad
+    class Foo; end # EOF
+
+    # good
+    class Foo; end
+    # EOF
+    ```
 
 <a name="character-encoding-and-magic-comments"></a>
 ## 文字エンコーディングとマジックコメント


### PR DESCRIPTION
The rule "Do not put empty lines at the end of a file." (in Japanese, "ファイルの末尾に空行を置いてはならない。") is a bit misleading. This rule forbids, for example, `puts "Hello"\n\n`, not `puts "Hello"\n`. Therefore I add a note by this pull req.