### PR TITLE
Enable Lint/AssignmentInCondition

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -203,6 +203,9 @@ Style/ParallelAssignment:
 # [MUST] Put whitespace around assignment operators.
 
 # [MUST] Do not write assignment expressions in conditional clauses.
+Lint/AssignmentInCondition:
+  Enabled: true
+  AllowSafeAssignment: false
 
 ########################
 # Control structures


### PR DESCRIPTION
Enable cop Lint/AssignmentInCondition, which is corresponding to:

https://github.com/cookpad/styleguide/blob/90e11b60cf94154b4ddab658fb336a4f69589608/ruby.en.md#L297

cf. https://docs.rubocop.org/en/stable/cops_lint/#lintassignmentincondition