### PR TITLE
Remove TargetRubyVersion config from .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
-  TargetRubyVersion: 2.5
   DisabledByDefault: true
   DisplayCopNames: true
   Exclude:


### PR DESCRIPTION
This styleguide is not for a specific ruby version.
So this PR removes TargetRubyVersion config from .rubocop.yml.

RuboCop will use the version specified in `.ruby-version` if it exists.
cf. https://docs.rubocop.org/en/stable/configuration/#setting-the-target-ruby-version