### PR TITLE
Ruby: Revise rule about braces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -261,9 +261,7 @@ Style/WhileUntilModifier:
 
 # [MUST] Do not put whitespace between a method name and parenthesis.
 
-# [SHOULD] Omit `{ }` of a hash literal, when put on the end of an argument list.
-Style/BracesAroundHashParameters:
-  EnforcedStyle: no_braces
+# [SHOULD] Due to separation of keyword and positional arguments in Ruby 3.0, distinguish between using keyword arguments and using a hash in method calls.
 
 # [MUST] Use `do`/`end` form for blocks of method calls where the return value of the block is unused. i.e. blocks executed for side-effects
 

--- a/ruby.en.md
+++ b/ruby.en.md
@@ -370,14 +370,26 @@ To ensure readability and consistency within the code, the guide presents a numb
     p (1 + 2)
     ```
 
-- **[SHOULD]** Omit `{ }` of a hash literal, when put on the end of an argument list.
+- **[SHOULD]** Due to separation of keyword and positional arguments in Ruby 3.0, distinguish between using keyword arguments and using a hash in method calls.
 
     ```ruby
-    # good
-    foo(1, 2, foo: :bar, baz: 42)
+    def foo(a:, b:)
+      p(a, b)
+    end
 
-    # bad
-    foo(1, 2, { foo: :bar, baz: 42 })
+    def bar(hash)
+      p(hash)
+    end
+
+    # good
+    foo(a: 1, b: 2)
+    # good
+    bar({a: 1, b: 2})
+
+    # bad - foo expects keyword arguments, but it passes a hash
+    foo({a: 1, b: 2})
+    # bad - bar expects a hash, but it passes keyword arguments
+    bar(a: 1, b: 2)
     ```
 
 - **[MUST]** Use `do`/`end` form for blocks of method calls where the return value of the block is unused. i.e. blocks executed for side-effects

--- a/ruby.ja.md
+++ b/ruby.ja.md
@@ -388,14 +388,26 @@ Ruby プログラマとしての素養をある程度備えている者なら誰
     p (1 + 2)
     ```
 
-- **[SHOULD]** パラメータリストの末尾にハッシュリテラルを書く場合は、ハッシュリテラルの括弧を省略すること。
+- **[SHOULD]** Ruby 3.0 からのキーワード引数とポジショナル引数の分離を踏まえ、メソッド呼び出しではキーワード引数に渡しているのかハッシュオブジェクトを渡しているのかを区別する。
 
     ```ruby
-    # good
-    foo(1, 2, foo: :bar, baz: 42)
+    def foo(a:, b:)
+      p(a, b)
+    end
 
-    # bad
-    foo(1, 2, { foo: :bar, baz: 42 })
+    def bar(hash)
+      p(hash)
+    end
+
+    # good
+    foo(a: 1, b: 2)
+    # good
+    bar({a: 1, b: 2})
+
+    # bad - foo expects keyword arguments, but it passes a hash
+    foo({a: 1, b: 2})
+    # bad - bar expects a hash, but it passes keyword arguments
+    bar(a: 1, b: 2)
     ```
 
 - **[MUST]** ブロック付きメソッド呼び出しでは、`do`/`end` 記法でブロックを書くこと。i.e. blockの副作用が目的


### PR DESCRIPTION
This pull request revises the following rule for Ruby:

> [SHOULD] Distinguish between using a hash and using keyword arguments in method calls.

Context: See #60.

This PR closes #60.