### PR TITLE
Correct the examples of do/end and braces for a block

### DIFF
--- a/ruby.en.md
+++ b/ruby.en.md
@@ -397,28 +397,28 @@ To ensure readability and consistency within the code, the guide presents a numb
 
     ```ruby
     # good
-    puts [1, 2, 3].map do |i|
-      i * i
-    end
-
-    # bad
     puts [1, 2, 3].map {|i|
       i * i
     }
 
+    # bad
+    puts [1, 2, 3].map do |i|
+      i * i
+    end
+
     # good
     [1, 2, 3].map {|n|
       n * n
-    }.each {|n|
+    }.each do |n|
       puts Math.sqrt(n)
-    }
+    end
 
     # bad
     [1, 2, 3].map do |n|
       n * n
-    end.each do |n|
+    end.each {|n|
       puts Math.sqrt(n)
-    end
+    }
     ```
 
 - **[MUST]** Use brace block for a method call written in one line.

--- a/ruby.ja.md
+++ b/ruby.ja.md
@@ -410,33 +410,33 @@ Ruby プログラマとしての素養をある程度備えている者なら誰
     bar(a: 1, b: 2)
     ```
 
-- **[MUST]** ブロック付きメソッド呼び出しでは、`do`/`end` 記法でブロックを書くこと。i.e. blockの副作用が目的
+- **[MUST]** ブロック付きメソッド呼び出しでブロックの戻り値を使わない場合（つまりブロックの副作用が目的の場合）は、`do`/`end` 記法でブロックを書くこと。
 - **[MUST]** ブロック付きメソッド呼び出しの戻り値に対して処理を行う場合は、ブロックを中括弧で書くこと。
 
     ```ruby
     # good
+    puts [1, 2, 3].map {|i|
+      i * i
+    }
+
+    # bad
     puts [1, 2, 3].map do |i|
       i * i
     end
-    
-    # bad
-    puts [1, 2, 3].map {|
-      i * i
-    }
 
     # good
     [1, 2, 3].map {|n|
       n * n
-    }.each {|n|
+    }.each do |n|
       puts Math.sqrt(n)
-    }
+    end
 
     # bad
     [1, 2, 3].map do |n|
       n * n
-    end.each do |n|
+    end.each {|n|
       puts Math.sqrt(n)
-    end
+    }
     ```
 
 - **[MUST]** ブロック付きメソッド呼び出しを1行で書く場合は、ブロックを中括弧で書くこと。


### PR DESCRIPTION
This code looks broken:

```ruby
# good
puts [1, 2, 3].map do |i|
  i * i
end
```

#51 changed the examples according to the rule written in Japanese, but I believe that the rule was mistranslated.  This change rephrases the rule, and reverts the change of #51.

In addition, I guess that the second example (below) is also wrong.

```ruby
# good
[1, 2, 3].map {|n|
  n * n
}.each {|n|
  puts Math.sqrt(n)
}
```

The block of `map` correctly uses braces as it returns a value that is used.  However, I think that the block of `each` should be `do` / `end` because the block is for side-effects.  According to the rules, it should be:

```ruby
# good
[1, 2, 3].map {|n|
  n * n
}.each do |n|
  puts Math.sqrt(n)
end
```