### PR TITLE
Change Layout/Tab to Layout/IndentationStyle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,8 +18,8 @@ AllCops:
 ########################
 
 # [MUST] Use two spaces for 1-level of indent. Do not use the horizontal tab character.
-Layout/Tab:
-  Enabled: true
+Layout/IndentationStyle:
+  EnforcedStyle: spaces
 Layout/IndentationWidth:
   Enabled: true
 Layout/IndentationConsistency:


### PR DESCRIPTION
[Rubocop 0.82](https://github.com/rubocop-hq/rubocop/releases/tag/v0.82.0) has a breaking change: `Layout/Tab` has been renamed to `Layout/IndentationStyle`. See https://github.com/rubocop-hq/rubocop/pull/7867 for details and https://docs.rubocop.org/en/stable/cops_layout/#layoutindentationstyle for document.

This pull request follows this change without changing our style.