### PR TITLE
Fixed typo: stuff -> staff

### DIFF
--- a/ruby.en.md
+++ b/ruby.en.md
@@ -42,7 +42,7 @@ To ensure readability and consistency within the code, the guide presents a numb
       merge(User.paid).
       where(created_at: target_date)
     posts.each do |post|
-      next if stuff_ids.include?(post.user_id)
+      next if staff_ids.include?(post.user_id)
       comment_count += post.comments.size
     end
 
@@ -50,7 +50,7 @@ To ensure readability and consistency within the code, the guide presents a numb
     posts = Post.joins(:user).
       merge(User.paid).
       where(created_at: target_date).each do |post|
-        next if stuff_ids.include?(post.user_id)
+        next if staff_ids.include?(post.user_id)
         comment_count += post.comments.size
       end
     ```

--- a/ruby.ja.md
+++ b/ruby.ja.md
@@ -46,7 +46,7 @@ Ruby プログラマとしての素養をある程度備えている者なら誰
       merge(User.paid).
       where(created_at: target_date)
     posts.each do |post|
-      next if stuff_ids.include?(post.user_id)
+      next if staff_ids.include?(post.user_id)
       comment_count += post.comments.size
     end
 
@@ -54,7 +54,7 @@ Ruby プログラマとしての素養をある程度備えている者なら誰
     posts = Post.joins(:user).
       merge(User.paid).
       where(created_at: target_date).each do |post|
-        next if stuff_ids.include?(post.user_id)
+        next if staff_ids.include?(post.user_id)
         comment_count += post.comments.size
       end
     ```


### PR DESCRIPTION
Since this is an example for users, `stuff` must be a typo of `staff`.