### PR TITLE
Relax block delimiter rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -263,13 +263,9 @@ Style/WhileUntilModifier:
 
 # [SHOULD] Due to separation of keyword and positional arguments in Ruby 3.0, distinguish between using keyword arguments and using a hash in method calls.
 
-# [MUST] Use the `do`/`end` form for multi-line blocks, except for the following cases:
-#   - Use the `{ }` form (i.e. brace blocks) for multi-line blocks when chaining other method calls to its return value.
-#   - Use the `{ }` form (i.e. brace blocks) for multi-line blocks where its return value is passed to another method as an argument.
+# [MUST] Use the `{ }` form (i.e. brace blocks) for multi-line blocks when chaining other method calls to its return value.
 
 # [MUST] Use brace block for a method call written in one line.
-# Style/BlockDelimiters:
-#   EnforcedStyle: braces_for_chaining
 
 # [MUST] Obey the following "good" form in `do`/`end` form of blocks.
 

--- a/ruby.en.md
+++ b/ruby.en.md
@@ -392,21 +392,9 @@ To ensure readability and consistency within the code, the guide presents a numb
     bar(a: 1, b: 2)
     ```
 
-- **[MUST]** Use the `do`/`end` form for multi-line blocks, except for the following cases:
-  - Use the `{ }` form (i.e. brace blocks) for multi-line blocks when chaining other method calls to its return value.
-  - Use the `{ }` form (i.e. brace blocks) for multi-line blocks where its return value is passed to another method as an argument.
+- **[MUST]** Use the `{ }` form (i.e. brace blocks) for multi-line blocks when chaining other method calls to its return value.
 
     ```ruby
-    # good
-    [1, 2, 3].each do |i|
-      puts i * i
-    end
-
-    # bad
-    [1, 2, 3].each {|i|
-      puts i * i
-    }
-
     # good - use { } when chaining methods
     [1, 2, 3].map {|n|
       n * n
@@ -416,16 +404,6 @@ To ensure readability and consistency within the code, the guide presents a numb
     [1, 2, 3].map do |n|
       n * n
     end.select(&:odd?)
-
-    # good - use { } when passing method calls with blocks to an other method call
-    do_something([1, 2, 3].map {|i|
-      i * i
-    })
-
-    # bad
-    do_something([1, 2, 3].map do |i|
-      i * i
-    end)
     ```
 
 - **[MUST]** Use brace block for a method call written in one line.

--- a/ruby.ja.md
+++ b/ruby.ja.md
@@ -410,21 +410,9 @@ Ruby プログラマとしての素養をある程度備えている者なら誰
     bar(a: 1, b: 2)
     ```
 
-- **[MUST]** ブロック付きメソッド呼び出しは、次の条件に合致しない限り `do`/`end` 記法でブロックを書くこと。
-  - ブロック付きメソッド呼び出しにメソッドをさらにチェーンする場合は、ブロックを中括弧 (`{ }`) で書くこと。
-  - ブロック付きメソッド呼び出しの式を他のメソッドの引数とする場合は、ブロックを中括弧 (`{ }`) で書くこと。
+- **[MUST]** ブロック付きメソッド呼び出しにメソッドをさらにチェーンする場合は、ブロックを中括弧 (`{ }`) で書くこと。
 
     ```ruby
-    # good
-    [1, 2, 3].each do |i|
-      puts i * i
-    end
-
-    # bad
-    [1, 2, 3].each {|i|
-      puts i * i
-    }
-
     # good - use { } when chaining methods
     [1, 2, 3].map {|n|
       n * n
@@ -434,16 +422,6 @@ Ruby プログラマとしての素養をある程度備えている者なら誰
     [1, 2, 3].map do |n|
       n * n
     end.select(&:odd?)
-
-    # good - use { } when passing method calls with blocks to an other method call
-    do_something([1, 2, 3].map {|i|
-      i * i
-    })
-
-    # bad
-    do_something([1, 2, 3].map do |i|
-      i * i
-    end)
     ```
 
 - **[MUST]** ブロック付きメソッド呼び出しを1行で書く場合は、ブロックを中括弧で書くこと。


### PR DESCRIPTION
do-end を一律で基本とするには例外が多い（各種の DSL や configure メソッド、RSpec の `it` `expect` など）という議論があったため、厳密なルールを定義するのではなく、メソッドチェーンする場合に限り do-end スタイルを禁止するように変更します。